### PR TITLE
chore: require redaxo 5.13.0

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -20,7 +20,7 @@ page:
         help:
             { title: 'translate:Help', subPath: README.md }
 requires:
-    redaxo: ^5.7.0
+    redaxo: ^5.13.0
     php:
         version: '>=8.0' 
         


### PR DESCRIPTION
`requireUser` wurde erst in 5.13.0 eingeführt:
https://github.com/redaxo/redaxo/blob/main/redaxo/src/core/CHANGELOG.md#version-5130--17112021