### PR TITLE
Installation: SERVER_ADDR verwenden statt REMOTE_ADDR

### DIFF
--- a/install.php
+++ b/install.php
@@ -24,7 +24,7 @@ if (array_key_exists('setup_addons', $data) && !in_array('maintenance', $data['s
 /* Eigene IP-Adresse in die erlaubten IP-Adressen hinzufügen, sofern nicht bereits vorhanden */
 $allowed_ips = strval($addon->getConfig('allowed_ips')); // @phpstan-ignore-line
 $allowed_ips = array_filter(explode(',', $allowed_ips)); // Leere Elemente entfernen
-$ip = rex_server('REMOTE_ADDR', 'string', '');
+$ip = rex_server('SERVER_ADDR', 'string', '');
 
 if (!in_array($ip, $allowed_ips, true)) {
     $allowed_ips[] = $ip;

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -77,7 +77,7 @@ maintenance_announcement_end_date_notice = Datum, bis wann die Ankündigung geze
 maintenance_allowed_access_title = Ausnahmen
 
 maintenance_allowed_ips_label = Liste erlaubter IP-Adressen
-maintenance_allowed_ips_notice = IP-Adresse(n) ein, die weiterhin Zugriff auf das Frontend haben soll(en). Die aktuelle IP-Adresse lautet <code>{0}</code>.
+maintenance_allowed_ips_notice = IP-Adresse(n) ein, die weiterhin Zugriff auf das Frontend haben soll(en). Deine aktuelle IP-Adresse lautet <code>{0}</code>, die des Servers lautet <code>{1}</code>.
 
 maintenance_allowed_domains_label = Liste erlaubter Domains
 maintenance_allowed_domains_notice = Domains eintragen, die nicht gesperrt werden sollen.

--- a/lang/el_gr.lang
+++ b/lang/el_gr.lang
@@ -74,7 +74,7 @@ maintenance_announcement_end_date_notice = Η ημερομηνία που η α�
 maintenance_allowed_access_title = Εξαιρέσεις
 
 maintenance_allowed_ips_label = Λίστα επιτρεπόμενων διευθύνσεων IP
-maintenance_allowed_ips_notice = Εισάγετε την(τις) διεύθυνση(εις) IP που θα συνεχίσουν να έχουν πρόσβαση στο frontend. Η τρέχουσα διεύθυνση IP σας: <code>{0}</code>.
+maintenance_allowed_ips_notice = Εισάγετε την(τις) διεύθυνση(εις) IP που θα συνεχίσουν να έχουν πρόσβαση στο frontend. Η τρέχουσα διεύθυνση IP σας: <code>{0}</code>
 
 maintenance_allowed_domains_label = Λίστα επιτρεπόμενων τομέων
 maintenance_allowed_domains_notice = Εισάγετε τους τομείς που δεν θα αποκλειστούν.

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -74,7 +74,7 @@ maintenance_announcement_end_date_notice = Date until when the announcement shou
 maintenance_allowed_access_title = Exceptions
 
 maintenance_allowed_ips_label = List of allowed IP addresses
-maintenance_allowed_ips_notice = Enter IP address(es) that should still have access to the frontend. The current IP address is <code>{0}</code>.
+maintenance_allowed_ips_notice = Enter IP address(es) that should still have access to the frontend. The current IP address is <code>{0}</code>, the IP address of the server is <code>{1}</code>.
 
 maintenance_allowed_domains_label = List of allowed domains
 maintenance_allowed_domains_notice = Enter domains that should not be blocked.

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -65,7 +65,7 @@ $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
 // Erlaubte IP-Adressen
 $field = $form->addTextField('allowed_ips');
 $field->setLabel($addon->i18n('maintenance_allowed_ips_label'));
-$field->setNotice($addon->i18n('maintenance_allowed_ips_notice', \rex_server('REMOTE_ADDR', 'string', '')));
+$field->setNotice($addon->i18n('maintenance_allowed_ips_notice', \rex_server('REMOTE_ADDR', 'string', ''), \rex_server('SERVER_ADDR', 'string', '')));
 $field->setAttribute('class', 'form-control');
 $field->setAttribute('data-maintenance', 'tokenfield');
 $field->setAttribute('data-beautify', 'false');


### PR DESCRIPTION
Und Ausgabe beider IP-Adressen.

Lokal ist mir das nicht aufgefallen, weil immer 127.0.0.1, aber online ist natürlich bevorzugt der Zugriff des eigenen Servers auf sich selbst zu erlauben, bspw. wegen Search It!.

![image](https://github.com/user-attachments/assets/fd85d896-bc0d-4663-8808-e30ab4663d8e)
