### PR TITLE
Verbesserungen beim Wartungsmodus und Clean Code

### DIFF
--- a/lib/Maintenance.php
+++ b/lib/Maintenance.php
@@ -14,34 +14,33 @@ use rex_login;
 use rex_response;
 use rex_user;
 use rex_yrewrite;
+
 use function in_array;
+
 use const FILTER_VALIDATE_IP;
 use const FILTER_VALIDATE_URL;
 
 /**
- * Class Maintenance
+ * Class Maintenance.
  * @package FriendsOfREDAXO\Maintenance
  */
 class Maintenance
 {
-    /** @var rex_addon|null */
     private static ?rex_addon $addon = null;
 
     /**
-     * Gets the addon instance
+     * Gets the addon instance.
      */
     private static function addon(): rex_addon
     {
-        if (self::$addon === null) {
+        if (null === self::$addon) {
             self::$addon = rex_addon::get('maintenance');
         }
         return self::$addon;
     }
 
     /**
-     * Checks if a URL is valid
-     * @param string $url
-     * @return bool|null
+     * Checks if a URL is valid.
      * @api
      */
     public function checkUrl(string $url): ?bool
@@ -56,9 +55,7 @@ class Maintenance
     }
 
     /**
-     * Checks if an IP address is valid
-     * @param string $ip
-     * @return bool|null
+     * Checks if an IP address is valid.
      * @api
      */
     public function checkIp(string $ip): ?bool
@@ -70,8 +67,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the current IP is allowed
-     * @return bool
+     * Checks if the current IP is allowed.
      * @api
      */
     public static function isIpAllowed(): bool
@@ -88,8 +84,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the current host is allowed
-     * @return bool
+     * Checks if the current host is allowed.
      * @api
      */
     public static function isHostAllowed(): bool
@@ -106,8 +101,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the current YRewrite domain is allowed
-     * @return bool
+     * Checks if the current YRewrite domain is allowed.
      * @api
      */
     public static function isYrewriteDomainAllowed(): bool
@@ -126,8 +120,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the maintenance secret is valid
-     * @return bool
+     * Checks if the maintenance secret is valid.
      * @api
      */
     public static function isSecretAllowed(): bool
@@ -153,8 +146,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the current user is allowed
-     * @return bool
+     * Checks if the current user is allowed.
      * @api
      */
     public static function isUserAllowed(): bool
@@ -169,7 +161,7 @@ class Maintenance
 
         // Prüfen ob der REDAXO-Benutzer gesperrt werden soll
         $block_frontend_rex_user = (bool) self::getConfig('block_frontend_rex_user', false);
-        
+
         // Wenn Benutzer eingeloggt ist und nicht gesperrt werden soll, dann Zugriff erlauben
         if ($user instanceof rex_user && !$block_frontend_rex_user) {
             return true;
@@ -179,8 +171,7 @@ class Maintenance
     }
 
     /**
-     * Checks frontend access and shows maintenance page if necessary
-     * @return void
+     * Checks frontend access and shows maintenance page if necessary.
      */
     public static function checkFrontend(): void
     {
@@ -234,14 +225,13 @@ class Maintenance
             rex_response::setStatus(rex_response::HTTP_MOVED_TEMPORARILY);
             rex_response::sendRedirect($redirect_url);
         }
-        
+
         header('HTTP/1.1 ' . $responsecode);
         exit($mpage->parse('maintenance/frontend.php'));
     }
 
     /**
-     * Checks backend access and shows maintenance page if necessary
-     * @return void
+     * Checks backend access and shows maintenance page if necessary.
      */
     public static function checkBackend(): void
     {
@@ -258,8 +248,7 @@ class Maintenance
     }
 
     /**
-     * Sets maintenance mode indicators in backend
-     * @return void
+     * Sets maintenance mode indicators in backend.
      */
     public static function setIndicators(): void
     {
@@ -280,8 +269,7 @@ class Maintenance
     }
 
     /**
-     * Shows maintenance announcement
-     * @return void
+     * Shows maintenance announcement.
      * @api
      */
     public static function showAnnouncement(): void
@@ -290,8 +278,7 @@ class Maintenance
     }
 
     /**
-     * Gets maintenance announcement if within announcement period
-     * @return string
+     * Gets maintenance announcement if within announcement period.
      * @api
      */
     public static function getAnnouncement(): string
@@ -310,21 +297,15 @@ class Maintenance
     }
 
     /**
-     * Gets config value with type casting
-     * @param string $key
-     * @param mixed $default
-     * @return mixed
+     * Gets config value with type casting.
      */
-    private static function getConfig(string $key, mixed $default = null): mixed 
+    private static function getConfig(string $key, mixed $default = null): mixed
     {
         return self::addon()->getConfig($key, $default);
     }
 
     /**
-     * Gets boolean config value
-     * @param string $key
-     * @param bool $default
-     * @return bool
+     * Gets boolean config value.
      */
     private static function getBoolConfig(string $key, bool $default = false): bool
     {

--- a/lib/Maintenance.php
+++ b/lib/Maintenance.php
@@ -14,27 +14,27 @@ use rex_login;
 use rex_response;
 use rex_user;
 use rex_yrewrite;
-
 use function in_array;
-
 use const FILTER_VALIDATE_IP;
 use const FILTER_VALIDATE_URL;
 
 /**
- * Class Maintenance.
+ * Class Maintenance
  * @package FriendsOfREDAXO\Maintenance
  */
 class Maintenance
 {
+    /** @var rex_addon */
     private static rex_addon $addon;
 
-    public function __construct()
-    {
+    static {
         self::$addon = rex_addon::get('maintenance');
     }
 
     /**
-     * Checks if a URL is valid.
+     * Checks if a URL is valid
+     * @param string $url
+     * @return bool|null
      * @api
      */
     public function checkUrl(string $url): ?bool
@@ -49,7 +49,9 @@ class Maintenance
     }
 
     /**
-     * Checks if an IP address is valid.
+     * Checks if an IP address is valid
+     * @param string $ip
+     * @return bool|null
      * @api
      */
     public function checkIp(string $ip): ?bool
@@ -61,7 +63,8 @@ class Maintenance
     }
 
     /**
-     * Checks if the current IP is allowed.
+     * Checks if the current IP is allowed
+     * @return bool
      * @api
      */
     public static function isIpAllowed(): bool
@@ -78,7 +81,8 @@ class Maintenance
     }
 
     /**
-     * Checks if the current host is allowed.
+     * Checks if the current host is allowed
+     * @return bool
      * @api
      */
     public static function isHostAllowed(): bool
@@ -95,7 +99,8 @@ class Maintenance
     }
 
     /**
-     * Checks if the current YRewrite domain is allowed.
+     * Checks if the current YRewrite domain is allowed
+     * @return bool
      * @api
      */
     public static function isYrewriteDomainAllowed(): bool
@@ -114,7 +119,8 @@ class Maintenance
     }
 
     /**
-     * Checks if the maintenance secret is valid.
+     * Checks if the maintenance secret is valid
+     * @return bool
      * @api
      */
     public static function isSecretAllowed(): bool
@@ -140,7 +146,8 @@ class Maintenance
     }
 
     /**
-     * Checks if the current user is allowed.
+     * Checks if the current user is allowed
+     * @return bool
      * @api
      */
     public static function isUserAllowed(): bool
@@ -155,7 +162,7 @@ class Maintenance
 
         // Prüfen ob der REDAXO-Benutzer gesperrt werden soll
         $block_frontend_rex_user = (bool) self::getConfig('block_frontend_rex_user', false);
-
+        
         // Wenn Benutzer eingeloggt ist und nicht gesperrt werden soll, dann Zugriff erlauben
         if ($user instanceof rex_user && !$block_frontend_rex_user) {
             return true;
@@ -165,7 +172,8 @@ class Maintenance
     }
 
     /**
-     * Checks frontend access and shows maintenance page if necessary.
+     * Checks frontend access and shows maintenance page if necessary
+     * @return void
      */
     public static function checkFrontend(): void
     {
@@ -219,13 +227,14 @@ class Maintenance
             rex_response::setStatus(rex_response::HTTP_MOVED_TEMPORARILY);
             rex_response::sendRedirect($redirect_url);
         }
-
+        
         header('HTTP/1.1 ' . $responsecode);
         exit($mpage->parse('maintenance/frontend.php'));
     }
 
     /**
-     * Checks backend access and shows maintenance page if necessary.
+     * Checks backend access and shows maintenance page if necessary
+     * @return void
      */
     public static function checkBackend(): void
     {
@@ -242,7 +251,8 @@ class Maintenance
     }
 
     /**
-     * Sets maintenance mode indicators in backend.
+     * Sets maintenance mode indicators in backend
+     * @return void
      */
     public static function setIndicators(): void
     {
@@ -263,7 +273,8 @@ class Maintenance
     }
 
     /**
-     * Shows maintenance announcement.
+     * Shows maintenance announcement
+     * @return void
      * @api
      */
     public static function showAnnouncement(): void
@@ -272,7 +283,8 @@ class Maintenance
     }
 
     /**
-     * Gets maintenance announcement if within announcement period.
+     * Gets maintenance announcement if within announcement period
+     * @return string
      * @api
      */
     public static function getAnnouncement(): string
@@ -291,15 +303,21 @@ class Maintenance
     }
 
     /**
-     * Gets config value with type casting.
+     * Gets config value with type casting
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
      */
-    private static function getConfig(string $key, mixed $default = null): mixed
+    private static function getConfig(string $key, mixed $default = null): mixed 
     {
         return self::$addon->getConfig($key, $default);
     }
 
     /**
-     * Gets boolean config value.
+     * Gets boolean config value
+     * @param string $key
+     * @param bool $default
+     * @return bool
      */
     private static function getBoolConfig(string $key, bool $default = false): bool
     {

--- a/lib/Maintenance.php
+++ b/lib/Maintenance.php
@@ -14,17 +14,18 @@ use rex_login;
 use rex_response;
 use rex_user;
 use rex_yrewrite;
+
 use function in_array;
+
 use const FILTER_VALIDATE_IP;
 use const FILTER_VALIDATE_URL;
 
 /**
- * Class Maintenance
+ * Class Maintenance.
  * @package FriendsOfREDAXO\Maintenance
  */
 class Maintenance
 {
-    /** @var rex_addon */
     private static rex_addon $addon;
 
     public function __construct()
@@ -33,9 +34,7 @@ class Maintenance
     }
 
     /**
-     * Checks if a URL is valid
-     * @param string $url
-     * @return bool|null
+     * Checks if a URL is valid.
      * @api
      */
     public function checkUrl(string $url): ?bool
@@ -50,9 +49,7 @@ class Maintenance
     }
 
     /**
-     * Checks if an IP address is valid
-     * @param string $ip
-     * @return bool|null
+     * Checks if an IP address is valid.
      * @api
      */
     public function checkIp(string $ip): ?bool
@@ -64,8 +61,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the current IP is allowed
-     * @return bool
+     * Checks if the current IP is allowed.
      * @api
      */
     public static function isIpAllowed(): bool
@@ -82,8 +78,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the current host is allowed
-     * @return bool
+     * Checks if the current host is allowed.
      * @api
      */
     public static function isHostAllowed(): bool
@@ -100,8 +95,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the current YRewrite domain is allowed
-     * @return bool
+     * Checks if the current YRewrite domain is allowed.
      * @api
      */
     public static function isYrewriteDomainAllowed(): bool
@@ -120,8 +114,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the maintenance secret is valid
-     * @return bool
+     * Checks if the maintenance secret is valid.
      * @api
      */
     public static function isSecretAllowed(): bool
@@ -147,8 +140,7 @@ class Maintenance
     }
 
     /**
-     * Checks if the current user is allowed
-     * @return bool
+     * Checks if the current user is allowed.
      * @api
      */
     public static function isUserAllowed(): bool
@@ -163,7 +155,7 @@ class Maintenance
 
         // Prüfen ob der REDAXO-Benutzer gesperrt werden soll
         $block_frontend_rex_user = (bool) self::getConfig('block_frontend_rex_user', false);
-        
+
         // Wenn Benutzer eingeloggt ist und nicht gesperrt werden soll, dann Zugriff erlauben
         if ($user instanceof rex_user && !$block_frontend_rex_user) {
             return true;
@@ -173,8 +165,7 @@ class Maintenance
     }
 
     /**
-     * Checks frontend access and shows maintenance page if necessary
-     * @return void
+     * Checks frontend access and shows maintenance page if necessary.
      */
     public static function checkFrontend(): void
     {
@@ -228,14 +219,13 @@ class Maintenance
             rex_response::setStatus(rex_response::HTTP_MOVED_TEMPORARILY);
             rex_response::sendRedirect($redirect_url);
         }
-        
+
         header('HTTP/1.1 ' . $responsecode);
         exit($mpage->parse('maintenance/frontend.php'));
     }
 
     /**
-     * Checks backend access and shows maintenance page if necessary
-     * @return void
+     * Checks backend access and shows maintenance page if necessary.
      */
     public static function checkBackend(): void
     {
@@ -252,8 +242,7 @@ class Maintenance
     }
 
     /**
-     * Sets maintenance mode indicators in backend
-     * @return void
+     * Sets maintenance mode indicators in backend.
      */
     public static function setIndicators(): void
     {
@@ -274,8 +263,7 @@ class Maintenance
     }
 
     /**
-     * Shows maintenance announcement
-     * @return void
+     * Shows maintenance announcement.
      * @api
      */
     public static function showAnnouncement(): void
@@ -284,8 +272,7 @@ class Maintenance
     }
 
     /**
-     * Gets maintenance announcement if within announcement period
-     * @return string
+     * Gets maintenance announcement if within announcement period.
      * @api
      */
     public static function getAnnouncement(): string
@@ -304,21 +291,15 @@ class Maintenance
     }
 
     /**
-     * Gets config value with type casting
-     * @param string $key
-     * @param mixed $default
-     * @return mixed
+     * Gets config value with type casting.
      */
-    private static function getConfig(string $key, mixed $default = null): mixed 
+    private static function getConfig(string $key, mixed $default = null): mixed
     {
         return self::$addon->getConfig($key, $default);
     }
 
     /**
-     * Gets boolean config value
-     * @param string $key
-     * @param bool $default
-     * @return bool
+     * Gets boolean config value.
      */
     private static function getBoolConfig(string $key, bool $default = false): bool
     {

--- a/lib/Maintenance.php
+++ b/lib/Maintenance.php
@@ -24,11 +24,18 @@ use const FILTER_VALIDATE_URL;
  */
 class Maintenance
 {
-    /** @var rex_addon */
-    private static rex_addon $addon;
+    /** @var rex_addon|null */
+    private static ?rex_addon $addon = null;
 
-    static {
-        self::$addon = rex_addon::get('maintenance');
+    /**
+     * Gets the addon instance
+     */
+    private static function addon(): rex_addon
+    {
+        if (self::$addon === null) {
+            self::$addon = rex_addon::get('maintenance');
+        }
+        return self::$addon;
     }
 
     /**
@@ -256,12 +263,12 @@ class Maintenance
      */
     public static function setIndicators(): void
     {
-        $page = self::$addon->getProperty('page');
+        $page = self::addon()->getProperty('page');
 
         if (self::getBoolConfig('block_backend', false)) {
             $page['title'] .= ' <span class="label label-info pull-right">B</span>';
             $page['icon'] .= ' fa-toggle-on block_backend';
-            self::$addon->setProperty('page', $page);
+            self::addon()->setProperty('page', $page);
         }
 
         if (self::getBoolConfig('block_frontend', false)) {
@@ -269,7 +276,7 @@ class Maintenance
             $page['icon'] .= ' fa-toggle-on block_frontend';
         }
 
-        self::$addon->setProperty('page', $page);
+        self::addon()->setProperty('page', $page);
     }
 
     /**
@@ -310,7 +317,7 @@ class Maintenance
      */
     private static function getConfig(string $key, mixed $default = null): mixed 
     {
-        return self::$addon->getConfig($key, $default);
+        return self::addon()->getConfig($key, $default);
     }
 
     /**

--- a/lib/Maintenance.php
+++ b/lib/Maintenance.php
@@ -31,7 +31,7 @@ class Maintenance
     /**
      * Gets the addon instance.
      */
-    private static function addon(): rex_addon
+    private static function getAddOn(): rex_addon
     {
         if (null === self::$addon) {
             self::$addon = rex_addon::get('maintenance');
@@ -252,12 +252,12 @@ class Maintenance
      */
     public static function setIndicators(): void
     {
-        $page = self::addon()->getProperty('page');
+        $page = self::getAddOn()->getProperty('page');
 
         if (self::getBoolConfig('block_backend', false)) {
             $page['title'] .= ' <span class="label label-info pull-right">B</span>';
             $page['icon'] .= ' fa-toggle-on block_backend';
-            self::addon()->setProperty('page', $page);
+            self::getAddOn()->setProperty('page', $page);
         }
 
         if (self::getBoolConfig('block_frontend', false)) {
@@ -265,7 +265,7 @@ class Maintenance
             $page['icon'] .= ' fa-toggle-on block_frontend';
         }
 
-        self::addon()->setProperty('page', $page);
+        self::getAddOn()->setProperty('page', $page);
     }
 
     /**
@@ -301,7 +301,7 @@ class Maintenance
      */
     private static function getConfig(string $key, mixed $default = null): mixed
     {
-        return self::addon()->getConfig($key, $default);
+        return self::getAddOn()->getConfig($key, $default);
     }
 
     /**

--- a/lib/Maintenance.php
+++ b/lib/Maintenance.php
@@ -127,7 +127,7 @@ class Maintenance
     {
         $config_secret = (string) self::getConfig('maintenance_secret', '');
 
-        // Prüfen ob bereits mit richtigem Secret eingeloggt
+        // Check if already logged in with the correct secret
         if ('' !== $config_secret && rex_session('maintenance_secret', 'string', '') === $config_secret) {
             return true;
         }
@@ -135,7 +135,7 @@ class Maintenance
         $maintenance_secret = rex_request('maintenance_secret', 'string', '');
         $authentification_mode = (string) self::getConfig('authentification_mode', '');
 
-        // Prüfen ob korrektes Secret per URL oder Passwort übergeben wurde
+        // Check if the correct secret is passed via URL or password
         if (('URL' === $authentification_mode || 'password' === $authentification_mode) && '' !== $config_secret && $maintenance_secret === $config_secret) {
             rex_set_session('maintenance_secret', $maintenance_secret);
             return true;
@@ -154,15 +154,15 @@ class Maintenance
         rex_backend_login::createUser();
         $user = rex::getUser();
 
-        // Admins haben immer Zugriff, unabhängig von Einstellungen
+        // Admins always have access, regardless of settings
         if ($user instanceof rex_user && $user->isAdmin()) {
             return true;
         }
 
-        // Prüfen ob der REDAXO-Benutzer gesperrt werden soll
+        // Check if the REDAXO user should be blocked
         $block_frontend_rex_user = (bool) self::getConfig('block_frontend_rex_user', false);
 
-        // Wenn Benutzer eingeloggt ist und nicht gesperrt werden soll, dann Zugriff erlauben
+        // If the user is logged in and should not be blocked, allow access
         if ($user instanceof rex_user && !$block_frontend_rex_user) {
             return true;
         }
@@ -177,38 +177,38 @@ class Maintenance
     {
         rex_login::startSession();
 
-        // Wenn die IP-Adresse erlaubt ist, Anfrage nicht sperren
+        // If the IP address is allowed, do not block the request
         if (self::isIpAllowed()) {
             return;
         }
 
-        // Wenn YRewrite installiert und Domain erlaubt ist, Anfrage nicht sperren
+        // If YRewrite is installed and the domain is allowed, do not block the request
         if (rex_addon::get('yrewrite')->isAvailable() && self::isYrewriteDomainAllowed()) {
             return;
         }
 
-        // Wenn der Host erlaubt ist, Anfrage nicht sperren
+        // If the host is allowed, do not block the request
         if (self::isHostAllowed()) {
             return;
         }
 
-        // Wenn das Secret / Passwort stimmt, Anfrage nicht sperren
+        // If the secret/password is correct, do not block the request
         if (self::isSecretAllowed()) {
             return;
         }
 
-        // Wenn der Benutzer zugelassen ist (Admin oder nicht-gesperrter Redakteur), Anfrage nicht sperren
+        // If the user is allowed (admin or non-blocked editor), do not block the request
         if (self::isUserAllowed()) {
             return;
         }
 
-        // Wenn die Sitemap angefordert wird, Anfrage nicht sperren
+        // If the sitemap is requested, do not block the request
         $REQUEST_URI = rex_server('REQUEST_URI', 'string', '');
         if (true === str_contains($REQUEST_URI, 'sitemap.xml')) {
             return;
         }
 
-        // EP zum Erlauben von Medien-Dateien
+        // EP to allow media files
         $media = rex_get('rex_media_file', 'string', '');
         $media_unblock = [];
         $media_unblocklist = rex_extension::registerPoint(new rex_extension_point('MAINTENANCE_MEDIA_UNBLOCK_LIST', $media_unblock));
@@ -216,7 +216,7 @@ class Maintenance
             return;
         }
 
-        // Alles, was bis hier hin nicht erlaubt wurde, blockieren wie in den Einstellungen gewählt
+        // Block everything that has not been allowed so far as chosen in the settings
         $redirect_url = (string) self::getConfig('redirect_frontend_to_url', '');
         $responsecode = (int) self::getConfig('http_response_code', 503);
 


### PR DESCRIPTION
# Verbesserungen beim Wartungsmodus und Clean Code

## Problem 
Redakteure wurden nicht korrekt gesperrt und der Code enthielt viele PHPStan-Warnungen. 

## Lösung
- Korrektur der Redakteurs-Sperrung durch Verwendung des korrekten Config-Keys
- Verbesserte statische Code-Analyse Kompatibilität (PHPStan)
- Robustere Typisierung und Fehlerbehandlung

### Wichtigste Änderungen:

1. **Redakteure-Sperrung korrigiert**
   - Korrekter Config-Key `block_frontend_rex_user` wird nun verwendet
   - Klare Logik: Admins haben immer Zugriff, Redakteure nur wenn sie nicht explizit gesperrt sind

2. **Bessere Code-Qualität**
   - Statische Typisierung durch korrekte PHPDoc-Blöcke
   - Zentrale Config-Zugriffsmethoden
   - Entfernung aller @phpstan-ignore-line Direktiven
   - Verbesserte Fehlerbehandlung

## Geprüft

- [x] Wartungsmodus funktioniert wie erwartet
- [x] Admins haben immer Zugriff
- [x] Redakteure werden korrekt gesperrt wenn aktiviert
- [x] PHPStan läuft ohne Warnungen durch
- [x] Bestehende Tests laufen erfolgreich durch
- [x] Code ist abwärtskompatibel