### PR TITLE
Fix console commands problems - console list working again

### DIFF
--- a/lib/command/maintenance_off.php
+++ b/lib/command/maintenance_off.php
@@ -9,7 +9,7 @@ class rex_maintenance_command_deactivate extends rex_console_command
     {
         // @phpstan-ignore-next-line
         $this->setAliases(['frontend:on'])
-            ->$this->setAliases(['maintenance:off'])
+            ->setAliases(['maintenance:off'])
             ->setDescription(rex_i18n::msg('maintenance_command_off_description'));
     }
 

--- a/lib/command/maintenance_on.php
+++ b/lib/command/maintenance_on.php
@@ -9,7 +9,7 @@ class rex_maintenance_command_activate extends rex_console_command
     {
         // @phpstan-ignore-next-line
         $this->setAliases(['frontend:off'])
-            ->$this->setAliases(['maintenance:on'])
+            ->setAliases(['maintenance:on'])
             ->setDescription(rex_i18n::msg('maintenance_command_on_description'));
     }
 

--- a/package.yml
+++ b/package.yml
@@ -30,10 +30,14 @@ requires:
     redaxo: ^5.17.0
     php:
         version: '>=8.2'
-        
+
 console_commands:
-       maintenance:frontend_disable: rex_maintenance_command_on
-       maintenance:frontend_enable: rex_maintenance_command_off
+       maintenance:activate: rex_maintenance_command_activate
+       maintenance:deactivate: rex_maintenance_command_deactivate
+       maintenance:on: rex_maintenance_command_activate
+       maintenance:off: rex_maintenance_command_deactivate
+       frontend:off: rex_maintenance_command_activate
+       frontend:on: rex_maintenance_command_deactivate
 
 default_config:
       http_response_code: 503 # 503, 403


### PR DESCRIPTION
Die Fehler bei den Kommandos erzeugten einen Fehler bei z.B. `bin/console list --raw` was von ydeploy benötigt wird, um das developer AddOn zum synchen zu bringen.