### PR TITLE
maintenance['frontend']

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -6,7 +6,7 @@ title: translate:maintenance_title
 
 page:
     title: translate:maintenance_title
-    perm: maintenance[]
+    perm: admin[]
     prio: 81
     block: system
     icon: 'maintenance rex-icon fa-toggle-off'
@@ -14,9 +14,11 @@ page:
         frontend:
             title: translate:maintenance_frontend_title
             icon: rex-icon fa-user
+            perm: maintenance[frontend]
         backend:
             title: translate:maintenance_backend_title
             icon: rex-icon fa-user-gear
+            perm: admin[]
         preview:
             title: translate:maintenance_preview_title
             icon: rex-icon fa-eye
@@ -26,6 +28,8 @@ page:
             subPath: README.md
             icon: rex-icon fa-question-circle
             itemClass: pull-right
+            perm: maintenance[frontend]
+
 requires:
     redaxo: ^5.17.0
     php:

--- a/package.yml
+++ b/package.yml
@@ -6,7 +6,7 @@ title: translate:maintenance_title
 
 page:
     title: translate:maintenance_title
-    perm: admin[]
+    perm: maintenance[]  # Grundlegendes Recht für den Zugriff auf das Addon
     prio: 81
     block: system
     icon: 'maintenance rex-icon fa-toggle-off'
@@ -23,17 +23,23 @@ page:
             title: translate:maintenance_preview_title
             icon: rex-icon fa-eye
             hidden: true
+            perm: maintenance[frontend]
         help:
             title: translate:maintenance_docs_title
             subPath: README.md
             icon: rex-icon fa-question-circle
             itemClass: pull-right
-            perm: maintenance[frontend]
+            perm: maintenance[]
 
 requires:
     redaxo: ^5.17.0
     php:
         version: '>=8.2'
+
+# Definition der verfügbaren Rechte für die Rollenverwaltung
+permissions:
+    maintenance[]: translate:maintenance[] # Grundlegendes Recht
+    maintenance[frontend]: translate:maintenance[frontend] # Recht für Frontend-Einstellungen
 
 console_commands:
        maintenance:activate: rex_maintenance_command_activate

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -11,56 +11,62 @@
  */
 
 $addon = rex_addon::get('maintenance');
+$isAdmin = rex::getUser()->isAdmin();
 
 $form = rex_config_form::factory($addon->getName());
 
 $form->addFieldset($addon->i18n('maintenance_general_title'));
 
-// Aktivierung/Deaktivierung des Wartungsmodus im Frontend
+// Activation/Deactivation of maintenance mode in frontend - visible for all users
 $field = $form->addSelectField('block_frontend');
 $field->setLabel($addon->i18n('maintenance_block_frontend_label'));
 $select = $field->getSelect();
-$select->addOption($addon->i18n('maintenance_block_frontend_false'), 0);
-$select->addOption($addon->i18n('maintenance_block_frontend_true'), 1);
+$select->addOption('Deaktiviert', 0, '<span><i class="fa-solid fa-circle-check text-success"></i> ' . rex_escape($addon->i18n('maintenance_block_frontend_false')) . ' <span class="badge badge-success">online</span></span>');
+$select->addOption('Aktiviert', 1, '<span><i class="fa-solid fa-circle-xmark text-danger"></i> ' . rex_escape($addon->i18n('maintenance_block_frontend_true')) . ' <span class="badge badge-danger">offline</span></span>');
+$select->setAttributes('class="form-control selectpicker" data-width="100%"');
 
-// Umgehung der Wartung durch GET-Parameter (URL) oder Passwort
-$field = $form->addSelectField('authentification_mode');
-$field->setLabel($addon->i18n('maintenance_authentification_mode_label'));
-$select = $field->getSelect();
-$select->addOption($addon->i18n('maintenance_authentification_mode_url'), 'URL');
-$select->addOption($addon->i18n('maintenance_authentification_mode_password'), 'password');
+if ($isAdmin) {
+    // Authentication mode selection - admin only
+    $field = $form->addSelectField('authentification_mode');
+    $field->setLabel($addon->i18n('maintenance_authentification_mode_label'));
+    $select = $field->getSelect();
+    $select->addOption('URL', 'URL', '<span><i class="fa-solid fa-link"></i> ' . rex_escape($addon->i18n('maintenance_authentification_mode_url')) . '</span>');
+    $select->addOption('Password', 'password', '<span><i class="fa-solid fa-key"></i> ' . rex_escape($addon->i18n('maintenance_authentification_mode_password')) . '</span>');
+    $select->setAttributes('class="form-control selectpicker" data-width="100%"');
 
-// Blockere auch für angemeldete REDAXO-Benutzer das Frontend
-$field = $form->addSelectField('block_frontend_rex_user');
-$field->setLabel($addon->i18n('maintenance_block_frontend_rex_user_label'));
-$select = $field->getSelect();
-$select->addOption($addon->i18n('maintenance_block_frontend_rex_user_false'), 0);
-$select->addOption($addon->i18n('maintenance_block_frontend_rex_user_rex_user'), 1);
+    // Block REDAXO users in frontend - admin only
+    $field = $form->addSelectField('block_frontend_rex_user');
+    $field->setLabel($addon->i18n('maintenance_block_frontend_rex_user_label'));
+    $select = $field->getSelect();
+    $select->addOption('Zugelassen', 0, '<span><i class="fa-solid fa-user-check text-success"></i> ' . rex_escape($addon->i18n('maintenance_block_frontend_rex_user_false')) . ' <span class="badge badge-success">erlaubt</span></span>');
+    $select->addOption('Gesperrt', 1, '<span><i class="fa-solid fa-user-xmark text-danger"></i> ' . rex_escape($addon->i18n('maintenance_block_frontend_rex_user_rex_user')) . ' <span class="badge badge-danger">gesperrt</span></span>');
+    $select->setAttributes('class="form-control selectpicker" data-width="100%"');
 
-// Passwort zum Umgehen des Wartungsmodus
-$field = $form->addTextField('maintenance_secret');
-$field->setLabel($addon->i18n('maintenance_secret_label'));
-$field->setNotice($addon->i18n('maintenance_secret_notice', bin2hex(random_bytes(16))));
-$field->setAttribute('type', 'password');
+    // Password for maintenance mode bypass - admin only
+    $field = $form->addTextField('maintenance_secret');
+    $field->setLabel($addon->i18n('maintenance_secret_label'));
+    $field->setNotice($addon->i18n('maintenance_secret_notice', bin2hex(random_bytes(16))));
+    $field->setAttribute('type', 'password');
 
-// Ziel der Umleitung
-$field = $form->addTextField('redirect_frontend_to_url');
-$field->setLabel($addon->i18n('maintenance_redirect_frontend_to_url_label'));
-$field->setNotice($addon->i18n('maintenance_redirect_frontend_to_url_notice'));
-$field->setAttribute('type', 'url');
+    // Redirect URL - admin only
+    $field = $form->addTextField('redirect_frontend_to_url');
+    $field->setLabel($addon->i18n('maintenance_redirect_frontend_to_url_label'));
+    $field->setNotice($addon->i18n('maintenance_redirect_frontend_to_url_notice'));
+    $field->setAttribute('type', 'url');
 
-// Antwortcode
-$field = $form->addSelectField('http_response_code');
-$field->setLabel($addon->i18n('maintenance_http_response_code_label'));
-$select = $field->getSelect();
-$select->addOption($addon->i18n('maintenance_http_response_code_503'), '503');
-$select->addOption($addon->i18n('maintenance_http_response_code_403'), '403');
+    // Response code - admin only
+    $field = $form->addSelectField('http_response_code');
+    $field->setLabel($addon->i18n('maintenance_http_response_code_label'));
+    $select = $field->getSelect();
+    $select->addOption('503', '503', '<span><i class="fa-solid fa-triangle-exclamation"></i> ' . rex_escape($addon->i18n('maintenance_http_response_code_503')) . '</span>');
+    $select->addOption('403', '403', '<span><i class="fa-solid fa-ban"></i> ' . rex_escape($addon->i18n('maintenance_http_response_code_403')) . '</span>');
+    $select->setAttributes('class="form-control selectpicker" data-width="100%"');
+}
 
-// Ausnahmeregeln
-
+// Exceptions section - visible for all users
 $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
 
-// Erlaubte IP-Adressen
+// Allowed IP addresses
 $field = $form->addTextField('allowed_ips');
 $field->setLabel($addon->i18n('maintenance_allowed_ips_label'));
 $field->setNotice($addon->i18n('maintenance_allowed_ips_notice', rex_server('REMOTE_ADDR', 'string', ''), rex_server('SERVER_ADDR', 'string', '')));
@@ -68,21 +74,21 @@ $field->setAttribute('class', 'form-control');
 $field->setAttribute('data-maintenance', 'tokenfield');
 $field->setAttribute('data-beautify', 'false');
 
-// Wenn YRewrite installiert, dann erlaubte YRewrite-Domains auswählen
+// YRewrite domains selection if available
 if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains()) > 1) {
     $field = $form->addSelectField('allowed_yrewrite_domains');
     $field->setAttribute('multiple', 'multiple');
-
     $field->setAttribute('class', 'form-control selectpicker');
     $field->setAttribute('data-live-search', 'true');
     $field->setLabel($addon->i18n('maintenance_allowed_yrewrite_domains_label'));
     $field->setNotice($addon->i18n('maintenance_allowed_yrewrite_domains_notice'));
     $select = $field->getSelect();
     foreach (rex_yrewrite::getDomains() as $key => $domain) {
-        $select->addOption($key, $key);
+        $select->addOption($key, $key, '<span><i class="fa-solid fa-globe"></i> ' . rex_escape($key) . '</span>');
     }
 }
-// Erlaubte Domains
+
+// Allowed domains
 $field = $form->addTextField('allowed_domains');
 $field->setLabel($addon->i18n('maintenance_allowed_domains_label'));
 $field->setNotice($addon->i18n('maintenance_allowed_domains_notice'));
@@ -90,33 +96,34 @@ $field->setAttribute('class', 'form-control');
 $field->setAttribute('data-maintenance', 'tokenfield');
 $field->setAttribute('data-beautify', 'false');
 
-// Wartungsfenster-Ankündigung
+if ($isAdmin) {
+    // Maintenance announcement section - admin only
+    $form->addFieldset($addon->i18n('maintenance_announcement_title'));
 
-$form->addFieldset($addon->i18n('maintenance_announcement_title'));
+    // Announcement text
+    $field = $form->addTextAreaField('announcement');
+    $field->setLabel($addon->i18n('maintenance_announcement_label'));
+    $field->setNotice($addon->i18n('maintenance_announcement_notice'));
+    if ('' !== (string) rex_config::get('maintenance', 'editor')) {
+        $field->setAttribute('class', '###maintenance-settings-editor###');
+    }
 
-// Benachrichtigungstext
-$field = $form->addTextAreaField('announcement');
-$field->setLabel($addon->i18n('maintenance_announcement_label'));
-$field->setNotice($addon->i18n('maintenance_announcement_notice'));
-if ('' !== (string) rex_config::get('maintenance', 'editor')) { // @phpstan-ignore-line
-    $field->setAttribute('class', '###maintenance-settings-editor###');
+    // Editor settings
+    $field = $form->addTextField('editor');
+    $field->setLabel($addon->i18n('maintenance_editor_label'));
+    $field->setNotice($addon->i18n('maintenance_editor_notice'));
+
+    // Announcement period
+    $field = $form->addTextField('announcement_start_date');
+    $field->setLabel($addon->i18n('maintenance_announcement_start_date_label'));
+    $field->setNotice($addon->i18n('maintenance_announcement_start_date_notice', date('Y-m-d H:i:s')));
+    $field->setAttribute('type', 'datetime-local');
+
+    $field = $form->addTextField('announcement_end_date');
+    $field->setLabel($addon->i18n('maintenance_announcement_end_date_label'));
+    $field->setNotice($addon->i18n('maintenance_announcement_end_date_notice', date('Y-m-d H:i:s')));
+    $field->setAttribute('type', 'datetime-local');
 }
-
-// Editor festlegen für Benachrichtigungstext
-$field = $form->addTextField('editor');
-$field->setLabel($addon->i18n('maintenance_editor_label'));
-$field->setNotice($addon->i18n('maintenance_editor_notice'));
-
-// Start- und Endzeitpunkt der Wartungsankündigung
-$field = $form->addTextField('announcement_start_date');
-$field->setLabel($addon->i18n('maintenance_announcement_start_date_label'));
-$field->setNotice($addon->i18n('maintenance_announcement_start_date_notice', date('Y-m-d H:i:s')));
-$field->setAttribute('type', 'datetime-local');
-
-$field = $form->addTextField('announcement_end_date');
-$field->setLabel($addon->i18n('maintenance_announcement_end_date_label'));
-$field->setNotice($addon->i18n('maintenance_announcement_end_date_notice', date('Y-m-d H:i:s')));
-$field->setAttribute('type', 'datetime-local');
 
 $fragment = new rex_fragment();
 $fragment->setVar('class', 'edit');
@@ -125,59 +132,57 @@ $fragment->setVar('body', $form->get(), false);
 ?>
 
 <div class="row">
-	<div class="col-lg-8">
-		<?= $fragment->parse('core/page/section.php') ?>
-	</div>
-	<div class="col-lg-4">
+    <div class="col-lg-8">
+        <?= $fragment->parse('core/page/section.php') ?>
+    </div>
+    <?php if ($isAdmin): ?>
+    <div class="col-lg-4">
+        <?php
+        /* Preview of maintenance mode */
+        $preview = '<a target="_blank" href="' . rex_url::backendPage('maintenance/preview') . '" class="btn btn-primary"><i class="fa-solid fa-eye"></i> ' . rex_i18n::msg('maintenance_preview') . '</a>';
 
+        $fragment = new rex_fragment();
+        $fragment->setVar('class', 'info', false);
+        $fragment->setVar('title', '<i class="fa-solid fa-eye"></i> ' . rex_i18n::msg('maintenance_preview_title'), false);
+        $fragment->setVar('body', $preview, false);
+        echo $fragment->parse('core/page/section.php');
 
-		<?php
-/* Vorschau des Wartungsmodus */
-$preview = '<a target="_blank" href="' . rex_url::backendPage('maintenance/preview') . '" class="btn btn-primary">' . rex_i18n::msg('maintenance_preview') . '</a>';
-
-$fragment = new rex_fragment();
-$fragment->setVar('class', 'info', false);
-$fragment->setVar('title', rex_i18n::msg('maintenance_preview_title'), false);
-$fragment->setVar('body', $preview, false);
-echo $fragment->parse('core/page/section.php');
-
-/* Kopieren der URL für den Wartungsmodus */
+        /* Copy maintenance mode URL */
         $copy = '<ul class="list-group">';
-$url = '' . rex::getServer() . '?maintenance_secret=' . rex_config::get('maintenance', 'maintenance_secret');
-$copy .= '<li class="list-group-item"><label for="maintenance-mode-url">REDAXO config.yml</label>
-<div class="hidden" id="maintenance-mode-url"><code>' . $url . '</code></div>';
-$copy .= '
-<clipboard-copy for="maintenance-mode-url" class="input-group">
-  <input type="text" value="' . $url . '" readonly class="form-control">
-  <span class="input-group-addon"><i class="rex-icon fa-clone"></i></span>
-</clipboad-copy></li>';
-
-// Ebenfalls für alle YRewrite-Domains ausgeben
-
-if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains()) > 1) {
-    foreach (rex_yrewrite::getDomains() as $key => $domain) {
-        if ('default' == $key) {
-            continue;
-        }
-        $url = $domain->getUrl() . '?maintenance_secret=' . rex_config::get('maintenance', 'maintenance_secret');
-        $copy .= '<li class="list-group-item"><label for="maintenance-mode-url-' . $key . '">YRewrite ' . $key . '</label>';
-        $copy .= '<div class="hidden" id="maintenance-mode-url-' . $key . '"><code>' . $url . '</code></div>';
+        $url = '' . rex::getServer() . '?maintenance_secret=' . rex_config::get('maintenance', 'maintenance_secret');
+        $copy .= '<li class="list-group-item"><label for="maintenance-mode-url"><i class="fa-solid fa-gear"></i> REDAXO config.yml</label>
+        <div class="hidden" id="maintenance-mode-url"><code>' . $url . '</code></div>';
         $copy .= '
-        <clipboard-copy for="maintenance-mode-url-' . $key . '" class="input-group">
+        <clipboard-copy for="maintenance-mode-url" class="input-group">
           <input type="text" value="' . $url . '" readonly class="form-control">
-          <span class="input-group-addon"><i class="rex-icon fa-clone"></i></span>
+          <span class="input-group-addon"><i class="fa-regular fa-copy"></i></span>
         </clipboad-copy></li>';
-    }
-}
 
-$copy .= '</ul>';
+        // Also output for all YRewrite domains
+        if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains()) > 1) {
+            foreach (rex_yrewrite::getDomains() as $key => $domain) {
+                if ('default' == $key) {
+                    continue;
+                }
+                $url = $domain->getUrl() . '?maintenance_secret=' . rex_config::get('maintenance', 'maintenance_secret');
+                $copy .= '<li class="list-group-item"><label for="maintenance-mode-url-' . $key . '"><i class="fa-solid fa-globe"></i> YRewrite ' . rex_escape($key) . '</label>';
+                $copy .= '<div class="hidden" id="maintenance-mode-url-' . $key . '"><code>' . $url . '</code></div>';
+                $copy .= '
+                <clipboard-copy for="maintenance-mode-url-' . $key . '" class="input-group">
+                  <input type="text" value="' . $url . '" readonly class="form-control">
+                  <span class="input-group-addon"><i class="fa-regular fa-copy"></i></span>
+                </clipboad-copy></li>';
+            }
+        }
 
-$fragment = new rex_fragment();
-$fragment->setVar('class', 'info', false);
-$fragment->setVar('title', rex_i18n::msg('maintenance_copy_url_title'), false);
-$fragment->setVar('body', $copy, false);
-echo $fragment->parse('core/page/section.php');
+        $copy .= '</ul>';
 
-?>
-	</div>
+        $fragment = new rex_fragment();
+        $fragment->setVar('class', 'info', false);
+        $fragment->setVar('title', '<i class="fa-regular fa-copy"></i> ' . rex_i18n::msg('maintenance_copy_url_title'), false);
+        $fragment->setVar('body', $copy, false);
+        echo $fragment->parse('core/page/section.php');
+        ?>
+    </div>
+    <?php endif; ?>
 </div>

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -17,56 +17,17 @@ $form = rex_config_form::factory($addon->getName());
 
 $form->addFieldset($addon->i18n('maintenance_general_title'));
 
-// Activation/Deactivation of maintenance mode in frontend - visible for all users
+// Aktivierung/Deaktivierung des Wartungsmodus im Frontend - für alle Benutzer verfügbar
 $field = $form->addSelectField('block_frontend');
 $field->setLabel($addon->i18n('maintenance_block_frontend_label'));
 $select = $field->getSelect();
-$select->addOption('Deaktiviert', 0, '<span><i class="fa-solid fa-circle-check text-success"></i> ' . rex_escape($addon->i18n('maintenance_block_frontend_false')) . ' <span class="badge badge-success">online</span></span>');
-$select->addOption('Aktiviert', 1, '<span><i class="fa-solid fa-circle-xmark text-danger"></i> ' . rex_escape($addon->i18n('maintenance_block_frontend_true')) . ' <span class="badge badge-danger">offline</span></span>');
-$select->setAttributes('class="form-control selectpicker" data-width="100%"');
+$select->addOption($addon->i18n('maintenance_block_frontend_false'), 0);
+$select->addOption($addon->i18n('maintenance_block_frontend_true'), 1);
 
-if ($isAdmin) {
-    // Authentication mode selection - admin only
-    $field = $form->addSelectField('authentification_mode');
-    $field->setLabel($addon->i18n('maintenance_authentification_mode_label'));
-    $select = $field->getSelect();
-    $select->addOption('URL', 'URL', '<span><i class="fa-solid fa-link"></i> ' . rex_escape($addon->i18n('maintenance_authentification_mode_url')) . '</span>');
-    $select->addOption('Password', 'password', '<span><i class="fa-solid fa-key"></i> ' . rex_escape($addon->i18n('maintenance_authentification_mode_password')) . '</span>');
-    $select->setAttributes('class="form-control selectpicker" data-width="100%"');
-
-    // Block REDAXO users in frontend - admin only
-    $field = $form->addSelectField('block_frontend_rex_user');
-    $field->setLabel($addon->i18n('maintenance_block_frontend_rex_user_label'));
-    $select = $field->getSelect();
-    $select->addOption('Zugelassen', 0, '<span><i class="fa-solid fa-user-check text-success"></i> ' . rex_escape($addon->i18n('maintenance_block_frontend_rex_user_false')) . ' <span class="badge badge-success">erlaubt</span></span>');
-    $select->addOption('Gesperrt', 1, '<span><i class="fa-solid fa-user-xmark text-danger"></i> ' . rex_escape($addon->i18n('maintenance_block_frontend_rex_user_rex_user')) . ' <span class="badge badge-danger">gesperrt</span></span>');
-    $select->setAttributes('class="form-control selectpicker" data-width="100%"');
-
-    // Password for maintenance mode bypass - admin only
-    $field = $form->addTextField('maintenance_secret');
-    $field->setLabel($addon->i18n('maintenance_secret_label'));
-    $field->setNotice($addon->i18n('maintenance_secret_notice', bin2hex(random_bytes(16))));
-    $field->setAttribute('type', 'password');
-
-    // Redirect URL - admin only
-    $field = $form->addTextField('redirect_frontend_to_url');
-    $field->setLabel($addon->i18n('maintenance_redirect_frontend_to_url_label'));
-    $field->setNotice($addon->i18n('maintenance_redirect_frontend_to_url_notice'));
-    $field->setAttribute('type', 'url');
-
-    // Response code - admin only
-    $field = $form->addSelectField('http_response_code');
-    $field->setLabel($addon->i18n('maintenance_http_response_code_label'));
-    $select = $field->getSelect();
-    $select->addOption('503', '503', '<span><i class="fa-solid fa-triangle-exclamation"></i> ' . rex_escape($addon->i18n('maintenance_http_response_code_503')) . '</span>');
-    $select->addOption('403', '403', '<span><i class="fa-solid fa-ban"></i> ' . rex_escape($addon->i18n('maintenance_http_response_code_403')) . '</span>');
-    $select->setAttributes('class="form-control selectpicker" data-width="100%"');
-}
-
-// Exceptions section - visible for all users
+// Ausnahmeregeln - für alle Benutzer verfügbar
 $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
 
-// Allowed IP addresses
+// Erlaubte IP-Adressen
 $field = $form->addTextField('allowed_ips');
 $field->setLabel($addon->i18n('maintenance_allowed_ips_label'));
 $field->setNotice($addon->i18n('maintenance_allowed_ips_notice', rex_server('REMOTE_ADDR', 'string', ''), rex_server('SERVER_ADDR', 'string', '')));
@@ -74,7 +35,7 @@ $field->setAttribute('class', 'form-control');
 $field->setAttribute('data-maintenance', 'tokenfield');
 $field->setAttribute('data-beautify', 'false');
 
-// YRewrite domains selection if available
+// Wenn YRewrite installiert, dann erlaubte YRewrite-Domains auswählen
 if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains()) > 1) {
     $field = $form->addSelectField('allowed_yrewrite_domains');
     $field->setAttribute('multiple', 'multiple');
@@ -84,11 +45,11 @@ if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains(
     $field->setNotice($addon->i18n('maintenance_allowed_yrewrite_domains_notice'));
     $select = $field->getSelect();
     foreach (rex_yrewrite::getDomains() as $key => $domain) {
-        $select->addOption($key, $key, '<span><i class="fa-solid fa-globe"></i> ' . rex_escape($key) . '</span>');
+        $select->addOption($key, $key);
     }
 }
 
-// Allowed domains
+// Erlaubte Domains
 $field = $form->addTextField('allowed_domains');
 $field->setLabel($addon->i18n('maintenance_allowed_domains_label'));
 $field->setNotice($addon->i18n('maintenance_allowed_domains_notice'));
@@ -96,11 +57,45 @@ $field->setAttribute('class', 'form-control');
 $field->setAttribute('data-maintenance', 'tokenfield');
 $field->setAttribute('data-beautify', 'false');
 
+// Ab hier nur für Admins sichtbare Optionen
 if ($isAdmin) {
-    // Maintenance announcement section - admin only
+    // Umgehung der Wartung durch GET-Parameter (URL) oder Passwort
+    $field = $form->addSelectField('authentification_mode');
+    $field->setLabel($addon->i18n('maintenance_authentification_mode_label'));
+    $select = $field->getSelect();
+    $select->addOption($addon->i18n('maintenance_authentification_mode_url'), 'URL');
+    $select->addOption($addon->i18n('maintenance_authentification_mode_password'), 'password');
+
+    // Blockere auch für angemeldete REDAXO-Benutzer das Frontend
+    $field = $form->addSelectField('block_frontend_rex_user');
+    $field->setLabel($addon->i18n('maintenance_block_frontend_rex_user_label'));
+    $select = $field->getSelect();
+    $select->addOption($addon->i18n('maintenance_block_frontend_rex_user_false'), 0);
+    $select->addOption($addon->i18n('maintenance_block_frontend_rex_user_rex_user'), 1);
+
+    // Passwort zum Umgehen des Wartungsmodus
+    $field = $form->addTextField('maintenance_secret');
+    $field->setLabel($addon->i18n('maintenance_secret_label'));
+    $field->setNotice($addon->i18n('maintenance_secret_notice', bin2hex(random_bytes(16))));
+    $field->setAttribute('type', 'password');
+
+    // Ziel der Umleitung
+    $field = $form->addTextField('redirect_frontend_to_url');
+    $field->setLabel($addon->i18n('maintenance_redirect_frontend_to_url_label'));
+    $field->setNotice($addon->i18n('maintenance_redirect_frontend_to_url_notice'));
+    $field->setAttribute('type', 'url');
+
+    // Antwortcode
+    $field = $form->addSelectField('http_response_code');
+    $field->setLabel($addon->i18n('maintenance_http_response_code_label'));
+    $select = $field->getSelect();
+    $select->addOption($addon->i18n('maintenance_http_response_code_503'), '503');
+    $select->addOption($addon->i18n('maintenance_http_response_code_403'), '403');
+
+    // Wartungsfenster-Ankündigung
     $form->addFieldset($addon->i18n('maintenance_announcement_title'));
 
-    // Announcement text
+    // Benachrichtigungstext
     $field = $form->addTextAreaField('announcement');
     $field->setLabel($addon->i18n('maintenance_announcement_label'));
     $field->setNotice($addon->i18n('maintenance_announcement_notice'));
@@ -108,12 +103,12 @@ if ($isAdmin) {
         $field->setAttribute('class', '###maintenance-settings-editor###');
     }
 
-    // Editor settings
+    // Editor festlegen für Benachrichtigungstext
     $field = $form->addTextField('editor');
     $field->setLabel($addon->i18n('maintenance_editor_label'));
     $field->setNotice($addon->i18n('maintenance_editor_notice'));
 
-    // Announcement period
+    // Start- und Endzeitpunkt der Wartungsankündigung
     $field = $form->addTextField('announcement_start_date');
     $field->setLabel($addon->i18n('maintenance_announcement_start_date_label'));
     $field->setNotice($addon->i18n('maintenance_announcement_start_date_notice', date('Y-m-d H:i:s')));
@@ -138,39 +133,39 @@ $fragment->setVar('body', $form->get(), false);
     <?php if ($isAdmin): ?>
     <div class="col-lg-4">
         <?php
-        /* Preview of maintenance mode */
-        $preview = '<a target="_blank" href="' . rex_url::backendPage('maintenance/preview') . '" class="btn btn-primary"><i class="fa-solid fa-eye"></i> ' . rex_i18n::msg('maintenance_preview') . '</a>';
+        /* Vorschau des Wartungsmodus */
+        $preview = '<a target="_blank" href="' . rex_url::backendPage('maintenance/preview') . '" class="btn btn-primary">' . rex_i18n::msg('maintenance_preview') . '</a>';
 
         $fragment = new rex_fragment();
         $fragment->setVar('class', 'info', false);
-        $fragment->setVar('title', '<i class="fa-solid fa-eye"></i> ' . rex_i18n::msg('maintenance_preview_title'), false);
+        $fragment->setVar('title', rex_i18n::msg('maintenance_preview_title'), false);
         $fragment->setVar('body', $preview, false);
         echo $fragment->parse('core/page/section.php');
 
-        /* Copy maintenance mode URL */
+        /* Kopieren der URL für den Wartungsmodus */
         $copy = '<ul class="list-group">';
         $url = '' . rex::getServer() . '?maintenance_secret=' . rex_config::get('maintenance', 'maintenance_secret');
-        $copy .= '<li class="list-group-item"><label for="maintenance-mode-url"><i class="fa-solid fa-gear"></i> REDAXO config.yml</label>
+        $copy .= '<li class="list-group-item"><label for="maintenance-mode-url">REDAXO config.yml</label>
         <div class="hidden" id="maintenance-mode-url"><code>' . $url . '</code></div>';
         $copy .= '
         <clipboard-copy for="maintenance-mode-url" class="input-group">
           <input type="text" value="' . $url . '" readonly class="form-control">
-          <span class="input-group-addon"><i class="fa-regular fa-copy"></i></span>
+          <span class="input-group-addon"><i class="rex-icon fa-clone"></i></span>
         </clipboad-copy></li>';
 
-        // Also output for all YRewrite domains
+        // Ebenfalls für alle YRewrite-Domains ausgeben
         if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains()) > 1) {
             foreach (rex_yrewrite::getDomains() as $key => $domain) {
                 if ('default' == $key) {
                     continue;
                 }
                 $url = $domain->getUrl() . '?maintenance_secret=' . rex_config::get('maintenance', 'maintenance_secret');
-                $copy .= '<li class="list-group-item"><label for="maintenance-mode-url-' . $key . '"><i class="fa-solid fa-globe"></i> YRewrite ' . rex_escape($key) . '</label>';
+                $copy .= '<li class="list-group-item"><label for="maintenance-mode-url-' . $key . '">YRewrite ' . $key . '</label>';
                 $copy .= '<div class="hidden" id="maintenance-mode-url-' . $key . '"><code>' . $url . '</code></div>';
                 $copy .= '
                 <clipboard-copy for="maintenance-mode-url-' . $key . '" class="input-group">
                   <input type="text" value="' . $url . '" readonly class="form-control">
-                  <span class="input-group-addon"><i class="fa-regular fa-copy"></i></span>
+                  <span class="input-group-addon"><i class="rex-icon fa-clone"></i></span>
                 </clipboad-copy></li>';
             }
         }
@@ -179,7 +174,7 @@ $fragment->setVar('body', $form->get(), false);
 
         $fragment = new rex_fragment();
         $fragment->setVar('class', 'info', false);
-        $fragment->setVar('title', '<i class="fa-regular fa-copy"></i> ' . rex_i18n::msg('maintenance_copy_url_title'), false);
+        $fragment->setVar('title', rex_i18n::msg('maintenance_copy_url_title'), false);
         $fragment->setVar('body', $copy, false);
         echo $fragment->parse('core/page/section.php');
         ?>

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -27,7 +27,7 @@ $select->addOption($addon->i18n('maintenance_block_frontend_true'), 1);
 if ($isAdmin) {
     // Erlaubte IP-Adressen - nur für Admins
     $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
-    
+
     $field = $form->addTextField('allowed_ips');
     $field->setLabel($addon->i18n('maintenance_allowed_ips_label'));
     $field->setNotice($addon->i18n('maintenance_allowed_ips_notice', rex_server('REMOTE_ADDR', 'string', ''), rex_server('SERVER_ADDR', 'string', '')));
@@ -41,7 +41,7 @@ if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains(
     if (!$isAdmin) {
         $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
     }
-    
+
     $field = $form->addSelectField('allowed_yrewrite_domains');
     $field->setAttribute('multiple', 'multiple');
     $field->setAttribute('class', 'form-control selectpicker');
@@ -184,5 +184,5 @@ $fragment->setVar('body', $form->get(), false);
         echo $fragment->parse('core/page/section.php');
         ?>
     </div>
-    <?php endif; ?>
+    <?php endif ?>
 </div>

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -24,19 +24,24 @@ $select = $field->getSelect();
 $select->addOption($addon->i18n('maintenance_block_frontend_false'), 0);
 $select->addOption($addon->i18n('maintenance_block_frontend_true'), 1);
 
-// Ausnahmeregeln - für alle Benutzer verfügbar
-$form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
+if ($isAdmin) {
+    // Erlaubte IP-Adressen - nur für Admins
+    $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
+    
+    $field = $form->addTextField('allowed_ips');
+    $field->setLabel($addon->i18n('maintenance_allowed_ips_label'));
+    $field->setNotice($addon->i18n('maintenance_allowed_ips_notice', rex_server('REMOTE_ADDR', 'string', ''), rex_server('SERVER_ADDR', 'string', '')));
+    $field->setAttribute('class', 'form-control');
+    $field->setAttribute('data-maintenance', 'tokenfield');
+    $field->setAttribute('data-beautify', 'false');
+}
 
-// Erlaubte IP-Adressen
-$field = $form->addTextField('allowed_ips');
-$field->setLabel($addon->i18n('maintenance_allowed_ips_label'));
-$field->setNotice($addon->i18n('maintenance_allowed_ips_notice', rex_server('REMOTE_ADDR', 'string', ''), rex_server('SERVER_ADDR', 'string', '')));
-$field->setAttribute('class', 'form-control');
-$field->setAttribute('data-maintenance', 'tokenfield');
-$field->setAttribute('data-beautify', 'false');
-
-// Wenn YRewrite installiert, dann erlaubte YRewrite-Domains auswählen
+// Wenn YRewrite installiert, dann erlaubte YRewrite-Domains auswählen - für alle Benutzer
 if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains()) > 1) {
+    if (!$isAdmin) {
+        $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
+    }
+    
     $field = $form->addSelectField('allowed_yrewrite_domains');
     $field->setAttribute('multiple', 'multiple');
     $field->setAttribute('class', 'form-control selectpicker');
@@ -49,16 +54,16 @@ if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains(
     }
 }
 
-// Erlaubte Domains
-$field = $form->addTextField('allowed_domains');
-$field->setLabel($addon->i18n('maintenance_allowed_domains_label'));
-$field->setNotice($addon->i18n('maintenance_allowed_domains_notice'));
-$field->setAttribute('class', 'form-control');
-$field->setAttribute('data-maintenance', 'tokenfield');
-$field->setAttribute('data-beautify', 'false');
-
 // Ab hier nur für Admins sichtbare Optionen
 if ($isAdmin) {
+    // Erlaubte Domains
+    $field = $form->addTextField('allowed_domains');
+    $field->setLabel($addon->i18n('maintenance_allowed_domains_label'));
+    $field->setNotice($addon->i18n('maintenance_allowed_domains_notice'));
+    $field->setAttribute('class', 'form-control');
+    $field->setAttribute('data-maintenance', 'tokenfield');
+    $field->setAttribute('data-beautify', 'false');
+
     // Umgehung der Wartung durch GET-Parameter (URL) oder Passwort
     $field = $form->addSelectField('authentification_mode');
     $field->setLabel($addon->i18n('maintenance_authentification_mode_label'));

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -33,7 +33,7 @@ $field->setAttribute('type', 'password');
 if ($isAdmin) {
     // Erlaubte IP-Adressen - nur für Admins
     $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
-    
+
     $field = $form->addTextField('allowed_ips');
     $field->setLabel($addon->i18n('maintenance_allowed_ips_label'));
     $field->setNotice($addon->i18n('maintenance_allowed_ips_notice', rex_server('REMOTE_ADDR', 'string', ''), rex_server('SERVER_ADDR', 'string', '')));
@@ -47,7 +47,7 @@ if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains(
     if (!$isAdmin) {
         $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
     }
-    
+
     $field = $form->addSelectField('allowed_yrewrite_domains');
     $field->setAttribute('multiple', 'multiple');
     $field->setAttribute('class', 'form-control selectpicker');
@@ -184,5 +184,5 @@ $fragment->setVar('body', $form->get(), false);
         echo $fragment->parse('core/page/section.php');
         ?>
     </div>
-    <?php endif; ?>
+    <?php endif ?>
 </div>

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -24,10 +24,16 @@ $select = $field->getSelect();
 $select->addOption($addon->i18n('maintenance_block_frontend_false'), 0);
 $select->addOption($addon->i18n('maintenance_block_frontend_true'), 1);
 
+// Passwort zum Umgehen des Wartungsmodus - für alle Benutzer verfügbar
+$field = $form->addTextField('maintenance_secret');
+$field->setLabel($addon->i18n('maintenance_secret_label'));
+$field->setNotice($addon->i18n('maintenance_secret_notice', bin2hex(random_bytes(16))));
+$field->setAttribute('type', 'password');
+
 if ($isAdmin) {
     // Erlaubte IP-Adressen - nur für Admins
     $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
-
+    
     $field = $form->addTextField('allowed_ips');
     $field->setLabel($addon->i18n('maintenance_allowed_ips_label'));
     $field->setNotice($addon->i18n('maintenance_allowed_ips_notice', rex_server('REMOTE_ADDR', 'string', ''), rex_server('SERVER_ADDR', 'string', '')));
@@ -41,7 +47,7 @@ if (rex_addon::get('yrewrite')->isAvailable() && count(rex_yrewrite::getDomains(
     if (!$isAdmin) {
         $form->addFieldset($addon->i18n('maintenance_allowed_access_title'));
     }
-
+    
     $field = $form->addSelectField('allowed_yrewrite_domains');
     $field->setAttribute('multiple', 'multiple');
     $field->setAttribute('class', 'form-control selectpicker');
@@ -77,12 +83,6 @@ if ($isAdmin) {
     $select = $field->getSelect();
     $select->addOption($addon->i18n('maintenance_block_frontend_rex_user_false'), 0);
     $select->addOption($addon->i18n('maintenance_block_frontend_rex_user_rex_user'), 1);
-
-    // Passwort zum Umgehen des Wartungsmodus
-    $field = $form->addTextField('maintenance_secret');
-    $field->setLabel($addon->i18n('maintenance_secret_label'));
-    $field->setNotice($addon->i18n('maintenance_secret_notice', bin2hex(random_bytes(16))));
-    $field->setAttribute('type', 'password');
 
     // Ziel der Umleitung
     $field = $form->addTextField('redirect_frontend_to_url');
@@ -184,5 +184,5 @@ $fragment->setVar('body', $form->get(), false);
         echo $fragment->parse('core/page/section.php');
         ?>
     </div>
-    <?php endif ?>
+    <?php endif; ?>
 </div>


### PR DESCRIPTION
Neue perm
maintenance['frontend']
<img width="876" alt="Bildschirmfoto 2024-12-28 um 18 06 17" src="https://github.com/user-attachments/assets/b0f2b910-e65d-4f11-8131-8ac017389d12" />


Für normale Frontend-Benutzer sind jetzt nur noch folgende Optionen verfügbar:

Ein-/Ausschalten des Wartungsmodus
YRewrite-Domains (wenn installiert)
Passwort ändern

Admins dürfen weiterhin alles
fixed: https://github.com/FriendsOfREDAXO/maintenance/issues/117