### PR TITLE
BUGFIX: Route aus LICENSE.md entfernt wegen Backendansicht

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-# MIT License
+MIT License
 
 Copyright (c) 2024 Friends Of REDAXO
 


### PR DESCRIPTION
### Beschreibung
Wegen dem `#` in der LICENSE.md, wird das `#` auch im Backend in der AddOn übersicht angezeigt:

![redaxo_addons_list_maintenance](https://github.com/user-attachments/assets/4f237623-07b9-419c-9fbb-219599d0742b)

Habe mir auch mal andere LICENSE Dateien aus anderen AddOns angeschaut. Dort wurde das `#` auch weggelassen.