### PR TITLE
FEATURE: Wartungsmodus-Überschrift für Backend und Frontend anpassbar gemacht

### DIFF
--- a/fragments/maintenance/backend.php
+++ b/fragments/maintenance/backend.php
@@ -1,3 +1,6 @@
+<?php
+    $maintenanceBackendHeadline = rex_config::get('maintenance', 'maintenance_backend_headline', 'Maintenance / Wartung');
+?>
 <!doctype html>
 <html lang="en">
 <head>
@@ -46,7 +49,7 @@
 <body>
     <div class="maintenance-container">
         <div class="maintenance-error">
-            <p class="maintenance-error-title">Maintenance<br>Wartung</p>
+            <p class="maintenance-error-title"><?= $maintenanceBackendHeadline ?></p>
             <p class="maintenance-error-message">Backend access has been blocked, please contact your administrator.</p>
             <p class="maintenance-error-message">Der Backend-Zugang wurde gesperrt, bitte kontaktieren Sie ihren Administrator.</p>
         </div>

--- a/fragments/maintenance/frontend.php
+++ b/fragments/maintenance/frontend.php
@@ -12,7 +12,7 @@
 <body>
     <div class="maintenance-container">
         <div class="maintenance-error">
-            <p class="maintenance-error-title"><?= $maintenanceFrontendHeadline ?></span></p>
+            <p class="maintenance-error-title"><?= $maintenanceFrontendHeadline ?></p>
             <p class="maintenance-error-message">This website is temporarily unavailable.</p>
             <p class="maintenance-error-message" lang="de">Diese Website ist vorübergehend nicht erreichbar.</p>
         </div>

--- a/fragments/maintenance/frontend.php
+++ b/fragments/maintenance/frontend.php
@@ -1,3 +1,6 @@
+<?php
+    $maintenanceFrontendHeadline = rex_config::get('maintenance', 'maintenance_frontend_headline', 'Maintenance / Wartung');
+?>
 <!doctype html>
 <html lang="en">
 <head>
@@ -9,7 +12,7 @@
 <body>
     <div class="maintenance-container">
         <div class="maintenance-error">
-            <p class="maintenance-error-title">Maintenance / <span lang="de">Wartung</span></p>
+            <p class="maintenance-error-title"><?= $maintenanceFrontendHeadline ?></span></p>
             <p class="maintenance-error-message">This website is temporarily unavailable.</p>
             <p class="maintenance-error-message" lang="de">Diese Website ist vorübergehend nicht erreichbar.</p>
         </div>

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -19,6 +19,9 @@ maintenance_mode_invalid = Ungültiges Argument! Benutze „on“ oder „off“
 
 // Einstellungsseite Backend
 
+maintenance_backend_headline_label = Backend-Überschrift  
+maintenance_backend_headline_notice = Geben Sie eine beliebige Überschrift für die Wartungsmodusmaske im Backend ein. Die Standardüberschrift lautet: "Maintenance / Wartung".
+
 maintenance_settings_backend_title = Wartungsmodus-Einstellungen für das REDAXO-Backend
 
 maintenance_block_backend_label = Wartungsmodus aktivieren
@@ -29,6 +32,9 @@ maintenance_redirect_backend_to_url_label = Weiterleitung zu (optional)
 maintenance_redirect_backend_to_url_notice = URL angeben, zu der die Benutzer weitergeleitet werden, wenn das REDAXO-Backend im Wartungsmodus ist.
 
 // Einstellungsseite Frontend
+
+maintenance_frontend_headline_label = Frontend-Überschrift  
+maintenance_frontend_headline_notice = Geben Sie eine beliebige Überschrift für die Wartungsmodusmaske im Frontend ein. Die Standardüberschrift lautet: "Maintenance / Wartung".  
 
 maintenance_settings_frontend_title = Wartungsmodus-Einstellungen für das Website-Frontend
 

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -19,6 +19,9 @@ maintenance_mode_invalid = Invalid argument! Use "on" or "off"
 
 // Backend Settings Page
 
+maintenance_backend_headline_label = Backend Headline  
+maintenance_backend_headline_notice = Enter any headline for the maintenance mode screen in the backend. The default headline is: "Maintenance / Wartung". 
+
 maintenance_settings_backend_title = Maintenance Mode Settings for the REDAXO Backend
 
 maintenance_block_backend_label = Activate maintenance mode
@@ -29,6 +32,9 @@ maintenance_redirect_backend_to_url_label = Redirect to (optional)
 maintenance_redirect_backend_to_url_notice = Specify the URL to which users will be redirected when the REDAXO backend is in maintenance mode.
 
 // Frontend Settings Page
+
+maintenance_frontend_headline_label = Frontend Headline  
+maintenance_frontend_headline_notice = Enter any headline for the maintenance mode screen in the frontend. The default headline is: "Maintenance / Wartung".
 
 maintenance_settings_frontend_title = Maintenance Mode Settings for the Website Frontend
 

--- a/package.yml
+++ b/package.yml
@@ -55,6 +55,8 @@ default_config:
       redirect_backend_to_url: '' # `https://example.com/maintenance.html`
       secret: ''
       editor: 'class="form-control redactor-editor--default"'
+      maintenance_frontend_headline: 'Maintenance / Wartung'
+      maintenance_backend_headline: 'Maintenance / Wartung'
 
 installer_ignore:
     - .git

--- a/pages/backend.php
+++ b/pages/backend.php
@@ -14,7 +14,7 @@ $addon = rex_addon::get('maintenance');
 
 $form = rex_config_form::factory($addon->getName());
 
-// Überschrift für denn Wartungsmodus
+// Überschrift für den Wartungsmodus
 $field = $form->addTextField('maintenance_backend_headline');
 $field->setLabel($addon->i18n('maintenance_backend_headline_label'));
 $field->setNotice($addon->i18n('maintenance_backend_headline_notice'));

--- a/pages/backend.php
+++ b/pages/backend.php
@@ -14,6 +14,11 @@ $addon = rex_addon::get('maintenance');
 
 $form = rex_config_form::factory($addon->getName());
 
+// Überschrift für denn Wartungsmodus
+$field = $form->addTextField('maintenance_backend_headline');
+$field->setLabel($addon->i18n('maintenance_backend_headline_label'));
+$field->setNotice($addon->i18n('maintenance_backend_headline_notice'));
+
 $field = $form->addSelectField('block_backend');
 $field->setLabel($addon->i18n('maintenance_block_backend_label'));
 $select = $field->getSelect();

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -17,7 +17,7 @@ $form = rex_config_form::factory($addon->getName());
 
 $form->addFieldset($addon->i18n('maintenance_general_title'));
 
-// Überschrift für denn Wartungsmodus
+// Überschrift für den Wartungsmodus
 $field = $form->addTextField('maintenance_frontend_headline');
 $field->setLabel($addon->i18n('maintenance_frontend_headline_label'));
 $field->setNotice($addon->i18n('maintenance_frontend_headline_notice'));

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -17,6 +17,11 @@ $form = rex_config_form::factory($addon->getName());
 
 $form->addFieldset($addon->i18n('maintenance_general_title'));
 
+// Überschrift für denn Wartungsmodus
+$field = $form->addTextField('maintenance_frontend_headline');
+$field->setLabel($addon->i18n('maintenance_frontend_headline_label'));
+$field->setNotice($addon->i18n('maintenance_frontend_headline_notice'));
+
 // Aktivierung/Deaktivierung des Wartungsmodus im Frontend - für alle Benutzer verfügbar
 $field = $form->addSelectField('block_frontend');
 $field->setLabel($addon->i18n('maintenance_block_frontend_label'));


### PR DESCRIPTION
### Beschreibung / Description
GitHub Issue: #112 
Bietet die Option, die Überschrift der Wartungsmodusmaske im Backend sowie im Frontend über den Editor zu pflegen.