### PR TITLE
FEATURE: Felder für Wartungsmodus-Aktualisierungsintervall hinzugefügt

### DIFF
--- a/fragments/maintenance/backend.php
+++ b/fragments/maintenance/backend.php
@@ -1,14 +1,16 @@
 <?php
     $maintenanceBackendHeadline = rex_config::get('maintenance', 'maintenance_backend_headline', 'Maintenance / Wartung');
+    $maintenanceBackendUpdateIntervalNumber = rex_config::get('maintenance', 'maintenance_backend_update_interval', 60);
 ?>
 <!doctype html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="refresh" content="<?= $maintenanceBackendUpdateIntervalNumber > 0 ? $maintenanceBackendUpdateIntervalNumber : '' ?>">
     <title>
         <?php
-            if (rex_addon::get('yrewrite')->isAvailable() && rex_yrewrite::getCurrentDomain()?->getName() !== null) {
+            if (rex_addon::get('yrewrite')->isAvailable() && null !== rex_yrewrite::getCurrentDomain()?->getName()) {
                 echo rex_yrewrite::getCurrentDomain()->getName();
             } else {
                 echo rex::getServerName();
@@ -64,4 +66,3 @@
     </div>
 </body>
 </html>'
-

--- a/fragments/maintenance/frontend.php
+++ b/fragments/maintenance/frontend.php
@@ -1,14 +1,16 @@
 <?php
     $maintenanceFrontendHeadline = rex_config::get('maintenance', 'maintenance_frontend_headline', 'Maintenance / Wartung');
+    $maintenanceFrontendUpdateIntervalNumber = rex_config::get('maintenance', 'maintenance_frontend_update_interval', 60);
 ?>
 <!doctype html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="refresh" content="<?= $maintenanceFrontendUpdateIntervalNumber > 0 ? $maintenanceFrontendUpdateIntervalNumber : '' ?>">
     <title>
         <?php
-            if (rex_addon::get('yrewrite')->isAvailable() && rex_yrewrite::getCurrentDomain()?->getName() !== null) {
+            if (rex_addon::get('yrewrite')->isAvailable() && null !== rex_yrewrite::getCurrentDomain()?->getName()) {
                 echo rex_yrewrite::getCurrentDomain()->getName();
             } else {
                 echo rex::getServerName();

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -5,6 +5,8 @@ maintenance_frontend_title = Website-Frontend
 maintenance_backend_title = REDAXO-Backend
 maintenance_docs_title = Hilfe
 
+maintenance_update_interval_field_label = Aktualisierungsintervall
+maintenance_update_interval_field_notice = Geben Sie die Sekunden ein, nach denen die Seite automatisch neu geladen werden soll. Setzen Sie 0, um die automatische Aktualisierung zu deaktivieren. Standardwert: 60 Sekunden
 
 // Console-Commands
 

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -5,6 +5,8 @@ maintenance_frontend_title = Website Frontend
 maintenance_backend_title = REDAXO Backend
 maintenance_docs_title = Documentation
 
+maintenance_update_interval_field_label = Update interval
+maintenance_update_interval_field_notice = Enter the number of seconds after which the page is automatically reloaded. Set 0 to deactivate the automatic refresh. Default value: 60 seconds
 
 // Console-Commands
 

--- a/lib/command/maintenance_mode.php
+++ b/lib/command/maintenance_mode.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class rex_maintenance_mode_command extends rex_console_command
 {
-    
     #[Override]
     protected function configure(): void
     {
@@ -15,7 +14,7 @@ class rex_maintenance_mode_command extends rex_console_command
             ->setName('maintenance:mode')
             ->setDescription(rex_i18n::msg('maintenance_mode_command_description'))
             ->addArgument(
-                "state",
+                'state',
                 InputArgument::OPTIONAL,
                 rex_i18n::msg('maintenance_mode_command_state_description'),
             );
@@ -26,36 +25,33 @@ class rex_maintenance_mode_command extends rex_console_command
     {
         $io = $this->getStyle($input, $output);
         $io->title(rex_i18n::msg('maintenance_title'));
-        
+
         $state = $input->getArgument('state');
 
         $addon = rex_addon::get('maintenance');
         $currentBlockFrontendConfiguration = $addon->getConfig();
 
-        if ($currentBlockFrontendConfiguration['block_frontend'] === 1 && $state === "on")
-        {
+        if (1 === $currentBlockFrontendConfiguration['block_frontend'] && 'on' === $state) {
             $io->info(rex_i18n::msg('maintenance_mode_already_activated'));
             return Command::FAILURE;
         }
 
-        if ($currentBlockFrontendConfiguration['block_frontend'] === 0 && $state === "off")
-        {
+        if (0 === $currentBlockFrontendConfiguration['block_frontend'] && 'off' === $state) {
             $io->info(rex_i18n::msg('maintenance_mode_already_deactivated'));
             return Command::FAILURE;
-        }        
-        
-        if ($state === "on")
-        {
+        }
+
+        if ('on' === $state) {
             $addon->setConfig('block_frontend', 1);
             $io->success(rex_i18n::msg('maintenance_mode_activated'));
-            return Command::SUCCESS;            
-        } elseif ($state === "off") {
+            return Command::SUCCESS;
+        }
+        if ('off' === $state) {
             $addon->setConfig('block_frontend', 0);
             $io->success(rex_i18n::msg('maintenance_mode_deactivated'));
             return Command::SUCCESS;
-        } else {
-            $io->error(rex_i18n::msg('maintenance_mode_invalid'));
-            return Command::INVALID;
         }
+        $io->error(rex_i18n::msg('maintenance_mode_invalid'));
+        return Command::INVALID;
     }
 }

--- a/package.yml
+++ b/package.yml
@@ -57,6 +57,8 @@ default_config:
       editor: 'class="form-control redactor-editor--default"'
       maintenance_frontend_headline: 'Maintenance / Wartung'
       maintenance_backend_headline: 'Maintenance / Wartung'
+      maintenance_frontend_update_interval: 60
+      maintenance_backend_update_interval: 60
 
 installer_ignore:
     - .git

--- a/pages/backend.php
+++ b/pages/backend.php
@@ -19,6 +19,12 @@ $field = $form->addTextField('maintenance_backend_headline');
 $field->setLabel($addon->i18n('maintenance_backend_headline_label'));
 $field->setNotice($addon->i18n('maintenance_backend_headline_notice'));
 
+// Automatische Aktualisierung der Seite
+$field = $form->addInputField('number', 'maintenance_backend_update_interval');
+$field->setLabel($addon->i18n('maintenance_update_interval_field_label'));
+$field->setNotice($addon->i18n('maintenance_update_interval_field_notice'));
+$field->setAttribute('class', 'form-control');
+
 $field = $form->addSelectField('block_backend');
 $field->setLabel($addon->i18n('maintenance_block_backend_label'));
 $select = $field->getSelect();

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -22,6 +22,12 @@ $field = $form->addTextField('maintenance_frontend_headline');
 $field->setLabel($addon->i18n('maintenance_frontend_headline_label'));
 $field->setNotice($addon->i18n('maintenance_frontend_headline_notice'));
 
+// Automatische Aktualisierung der Seite
+$field = $form->addInputField('number', 'maintenance_frontend_update_interval');
+$field->setLabel($addon->i18n('maintenance_update_interval_field_label'));
+$field->setNotice($addon->i18n('maintenance_update_interval_field_notice'));
+$field->setAttribute('class', 'form-control');
+
 // Aktivierung/Deaktivierung des Wartungsmodus im Frontend - für alle Benutzer verfügbar
 $field = $form->addSelectField('block_frontend');
 $field->setLabel($addon->i18n('maintenance_block_frontend_label'));

--- a/pages/index.php
+++ b/pages/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the maintenance package.
  *


### PR DESCRIPTION
**Description / Beschreibung**

GitHub Issue: #123 

Fügt die Option hinzu, das Aktualisierungsintervall in Sekunden für das Frontend, und Backend bei aktivierendem Wartungsmodus anzugeben.

### Zu klären:

Man könnte noch darüber diskutieren, ob man noch die Option ergänzen möchte, auf eine URL weiterzuleiten:

```html
<meta http-equiv="refresh" content="3;url=https://www.mozilla.org" />
```
Dafür ist mir jetzt aber kein Anwendungsfall eingefallen.

Und ob man, wenn man `0` Sekunden, oder z.B. `-1` angibt, denn Meta-Tag nicht rendern möchte. Oder ob es so wie es jetzt ist in Ordnung ist (content wird auf leer gesetzt).