### PR TITLE
BUGFIX: strong Tag formatierung beim hinweistext im startdatum feld korrigiert

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -82,7 +82,7 @@ maintenance_announcement_start_date_label = Startdatum
 maintenance_announcement_start_date_notice = Datum, <strong>ab wann die Ankündigung gezeigt werden soll</strong>. Nicht, ab wann die Website in den Wartungsmodus wechseln soll. Aktuelle Serverzeit: <code>{0}</code>.
 
 maintenance_announcement_end_date_label = Enddatum
-maintenance_announcement_end_date_notice = Datum, bis wann die Ankündigung gezeigt werden soll. Aktuelle Serverzeit: <code>{0}</code>.
+maintenance_announcement_end_date_notice = Datum, <strong>bis wann die Ankündigung gezeigt werden soll</strong>. Aktuelle Serverzeit: <code>{0}</code>.
 
 maintenance_allowed_access_title = Ausnahmen
 

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -79,7 +79,7 @@ maintenance_announcement_start_date_label = Start Date
 maintenance_announcement_start_date_notice = Date from <strong>when the announcement should be shown</strong>. Not from when the website will switch to maintenance mode. Current server time: <code>{0}</code>.
 
 maintenance_announcement_end_date_label = End Date
-maintenance_announcement_end_date_notice = Date until when the announcement should be shown. Current server time: <code>{0}</code>.
+maintenance_announcement_end_date_notice = Date <strong>until when the announcement should be shown</strong>. Current server time: <code>{0}</code>.
 
 maintenance_allowed_access_title = Exceptions
 

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -121,7 +121,7 @@ if ($isAdmin) {
     // Start- und Endzeitpunkt der Wartungsankündigung
     $field = $form->addTextField('announcement_start_date');
     $field->setLabel($addon->i18n('maintenance_announcement_start_date_label'));
-    $field->setNotice($addon->i18n('maintenance_announcement_start_date_notice', date('Y-m-d H:i:s')));
+    $field->setNotice(rex_i18n::rawMsg('maintenance_announcement_start_date_notice', date('Y-m-d H:i:s')));
     $field->setAttribute('type', 'datetime-local');
 
     $field = $form->addTextField('announcement_end_date');

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -126,7 +126,7 @@ if ($isAdmin) {
 
     $field = $form->addTextField('announcement_end_date');
     $field->setLabel($addon->i18n('maintenance_announcement_end_date_label'));
-    $field->setNotice($addon->i18n('maintenance_announcement_end_date_notice', date('Y-m-d H:i:s')));
+    $field->setNotice(rex_i18n::rawMsg('maintenance_announcement_end_date_notice', date('Y-m-d H:i:s')));
     $field->setAttribute('type', 'datetime-local');
 }
 


### PR DESCRIPTION
**Description / Beschreibung**
GitHub Issue: #134
Zeigt denn Hinweistext beim Startdatum feld wieder korrekt an:

![image](https://github.com/user-attachments/assets/e9dc8c35-82c1-453c-b4d2-7659a7606fa7)

