### PR TITLE
`_clear_cache/_clear_cache.php` Aufruf erlauben

### DIFF
--- a/lib/Maintenance.php
+++ b/lib/Maintenance.php
@@ -210,6 +210,12 @@ class Maintenance
         if (true === str_contains($REQUEST_URI, 'sitemap.xml')) {
             return;
         }
+        
+        // If YDeploy is used, do not block the request
+        $REQUEST_URI = rex_server('REQUEST_URI', 'string', '');
+        if (true === str_contains($REQUEST_URI, '_clear_cache/_clear_cache.php')) {
+            return;
+        }
 
         // EP to allow media files
         $media = rex_get('rex_media_file', 'string', '');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of specific request URIs to ensure maintenance mode is bypassed for cache-clearing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->